### PR TITLE
fix(command/start): can't found cli.js module on daemon mode

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -95,7 +95,7 @@ function _daemonServer () {
   var env = process.env;
   var out = fs.openSync(path.join(logsDir, 'out.log'), 'a');
   var err = fs.openSync(path.join(logsDir, 'err.log'), 'a');
-  var binPath = path.resolve(__filename, '../../cli.js');
+  var binPath = path.resolve(__filename, '../../bin/cli.js');
 
   env.__daemon = true;
 


### PR DESCRIPTION
daemon mode can't found cli.js because of cli.js has been moved to `bin` directory